### PR TITLE
Add i18n support to pydantic form

### DIFF
--- a/src/fastlife/adapters/jinjax/widgets/base.py
+++ b/src/fastlife/adapters/jinjax/widgets/base.py
@@ -55,7 +55,7 @@ class Widget(JinjaXTemplate, Generic[T]):
     aria_label: str | None = Field(default=None)
     "Non visible text alternative."
     token: str = Field(default="")
-    "unique token to ensure id are unique in the DOM."
+    "Unique token to ensure id are unique in the DOM."
     removable: bool = Field(default=False)
     "Indicate that the widget is removable from the dom."
 

--- a/src/fastlife/adapters/jinjax/widgets/boolean.py
+++ b/src/fastlife/adapters/jinjax/widgets/boolean.py
@@ -16,7 +16,7 @@ class BooleanWidget(Widget[bool]):
         <div class="flex items-center">
          <Checkbox :name="name" :id="id" :checked="value" value="1" />
          <Label :for="id" class="ms-2 text-base text-neutral-900 dark:text-white">
-            {{title|safe}}
+            {{ gettext(title)|safe }}
           </Label>
         </div>
        <pydantic_form.Error :text="error" />

--- a/src/fastlife/adapters/jinjax/widgets/checklist.py
+++ b/src/fastlife/adapters/jinjax/widgets/checklist.py
@@ -40,7 +40,7 @@ class ChecklistWidget(Widget[Sequence[Checkable]]):
       <div class="pt-4">
         <Details>
           <Summary :id="id + '-summary'">
-            <H3 :class="H3_SUMMARY_CLASS">{{title}}</H3>
+            <H3 :class="H3_SUMMARY_CLASS">{{ gettext(title) }}</H3>
             <pydantic_form.Error :text="error" />
           </Summary>
           <div>
@@ -52,7 +52,7 @@ class ChecklistWidget(Widget[Sequence[Checkable]]):
                     :checked="value.checked" />
                 <Label :for="value.id"
                     class="ms-2 text-base text-neutral-900 dark:text-white">
-                    {{- value.label -}}
+                    {{- gettext(value.label) -}}
                 </Label>
                 <pydantic_form.Error :text="value.error" />
             </div>

--- a/src/fastlife/adapters/jinjax/widgets/dropdown.py
+++ b/src/fastlife/adapters/jinjax/widgets/dropdown.py
@@ -17,12 +17,12 @@ class DropDownWidget(Widget[str]):
     template = """
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <div class="pt-4">
-        <Label :for="id">{{title}}</Label>
+        <Label :for="id">{{ gettext(title) }}</Label>
         <Select :name="name" :id="id">
           {%- for opt in options -%}
           <Option :value="opt.value" id={{id + "-" + opt.value.replace(" ", " -")}}
             :selected="value==opt.value">
-            {{- opt.text -}}
+            {{- gettext(opt.text) -}}
           </Option>
           {%- endfor -%}
         </Select>

--- a/src/fastlife/adapters/jinjax/widgets/mfa_code.py
+++ b/src/fastlife/adapters/jinjax/widgets/mfa_code.py
@@ -11,7 +11,7 @@ class MFACodeWidget(Widget[str]):
     template = """
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <div class="pt-4">
-        <Label :for="id">{{title}}</Label>
+        <Label :for="id">{{ gettext(title) }}</Label>
         <pydantic_form.Error :text="error" />
         <Input :name="name" type="text" :id="id" inputmode="numeric"
             autocomplete="one-time-code" :autofocus="autofocus"

--- a/src/fastlife/adapters/jinjax/widgets/model.py
+++ b/src/fastlife/adapters/jinjax/widgets/model.py
@@ -17,7 +17,7 @@ class ModelWidget(Widget[Sequence[TWidget]]):
         {% if nested %}
         <Details>
         <Summary :id="id + '-summary'">
-            <H3 :class="H3_SUMMARY_CLASS">{{title}}</H3>
+            <H3 :class="H3_SUMMARY_CLASS">{{ gettext(title) }}</H3>
             <pydantic_form.Error :text="error" />
         </Summary>
         <div>

--- a/src/fastlife/adapters/jinjax/widgets/sequence.py
+++ b/src/fastlife/adapters/jinjax/widgets/sequence.py
@@ -14,7 +14,7 @@ class SequenceWidget(Widget[Sequence[TWidget]]):
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <Details :id="id">
         <Summary :id="id + '-summary'">
-          <H3 :class="H3_SUMMARY_CLASS">{{title}}</H3>
+          <H3 :class="H3_SUMMARY_CLASS">{{ gettext(title) }}</H3>
           <pydantic_form.Error :text="error" />
         </Summary>
         <div>

--- a/src/fastlife/adapters/jinjax/widgets/text.py
+++ b/src/fastlife/adapters/jinjax/widgets/text.py
@@ -15,7 +15,7 @@ class TextWidget(Widget[Builtins]):
     template = """
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <div class="pt-4">
-        <Label :for="id">{{title}}</Label>
+        <Label :for="id">{{ gettext(title) }}</Label>
         <pydantic_form.Error :text="error" />
         <Input :name="name" :value="value" :type="input_type" :id="id"
           :aria-label="aria_label" :placeholder="placeholder"
@@ -26,19 +26,22 @@ class TextWidget(Widget[Builtins]):
     """
 
     input_type: str = Field(default="text")
+    """type attribute for the Input component."""
     placeholder: str | None = Field(default=None)
+    """placeholder attribute for the Input component."""
     autocomplete: str | None = Field(default=None)
+    """autocomplete attribute for the Input component."""
 
 
 class PasswordWidget(Widget[SecretStr]):
     """
-    Widget for text like field (email, ...).
+    Widget for password fields.
     """
 
     template = """
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <div class="pt-4">
-        <Label :for="id">{{title}}</Label>
+        <Label :for="id">{{ gettext(title) }}</Label>
         <pydantic_form.Error :text="error" />
         <Password :name="name" :type="input_type" :id="id"
           autocomplete={{
@@ -51,8 +54,13 @@ class PasswordWidget(Widget[SecretStr]):
     """
 
     input_type: str = Field(default="password")
+    """type attribute for the Input component."""
     placeholder: str | None = Field(default=None)
+    """placeholder attribute for the Input component."""
     new_password: bool = Field(default=False)
+    """
+    Adapt autocomplete behavior for browsers to hint existing or generate password.
+    """
 
 
 class TextareaWidget(Widget[str | Sequence[str]]):
@@ -81,7 +89,7 @@ class TextareaWidget(Widget[str | Sequence[str]]):
     template = """
     <pydantic_form.Widget :widget_id="id" :removable="removable">
       <div class="pt-4">
-        <Label :for="id">{{title}}</Label>
+        <Label :for="id">{{ gettext(title) }}</Label>
         <pydantic_form.Error :text="error" />
         <Textarea :name="name" :id="id" :aria-label="aria_label">
             {%- if value is string -%}
@@ -94,5 +102,3 @@ class TextareaWidget(Widget[str | Sequence[str]]):
       </div>
     </pydantic_form.Widget>
     """
-
-    placeholder: str = Field(default="")

--- a/src/fastlife/adapters/jinjax/widgets/union.py
+++ b/src/fastlife/adapters/jinjax/widgets/union.py
@@ -23,7 +23,7 @@ class UnionWidget(Widget[TWidget]):
       <div id="{{id}}">
         <Details>
           <Summary :id="id + '-union-summary'">
-            <H3 :class="H3_SUMMARY_CLASS">{{title}}</H3>
+            <H3 :class="H3_SUMMARY_CLASS">{{ gettext(title) }}</H3>
             <pydantic_form.Error :text="error" />
           </Summary>
           <div hx-sync="this" id="{{id}}-child">
@@ -37,7 +37,7 @@ class UnionWidget(Widget[TWidget]):
                 :hx-vals="typ.params|tojson"
                 :id="typ.id"
                 onclick={{ "document.getElementById('" + id + "-remove-btn').hidden=false" }}
-              :class="SECONDARY_BUTTON_CLASS">{{typ.title}}</Button>
+              :class="SECONDARY_BUTTON_CLASS">{{ gettext(typ.title) }}</Button>
             {% endfor %}
             {% endif %}
           </div>

--- a/src/fastlife/components/Input.jinja
+++ b/src/fastlife/components/Input.jinja
@@ -42,8 +42,8 @@
 
 <input name="{{name}}" value="{{value|default('')}}" type="{{type}}"
   {%- if id %} id="{{id}}" {%- endif %}
-  {%- if aria_label %} aria-label="{{aria_label}}" {%- endif %}
-  {%- if placeholder %} placeholder="{{placeholder}}" {%- endif %}
+  {%- if aria_label %} aria-label="{{ gettext(aria_label) }}" {%- endif %}
+  {%- if placeholder %} placeholder="{{ gettext(placeholder) }}" {%- endif %}
   {%- if inputmode %} inputmode="{{inputmode}}" {%- endif %}
   {%- if autocomplete %} autocomplete="{{autocomplete}}" {%- endif %}
   class="{{attrs.class or INPUT_CLASS}}"

--- a/src/fastlife/components/Label.jinja
+++ b/src/fastlife/components/Label.jinja
@@ -14,5 +14,5 @@
     {%- if attrs.for %} for="{{attrs.for}}" {%- endif %}
     class="{{attrs.class or LABEL_CLASS}}"
     {%- if id %} id="{{id}}" {%- endif %}>
-  {{-content -}}
+  {{- content -}}
 </label>

--- a/src/fastlife/config/configurator.py
+++ b/src/fastlife/config/configurator.py
@@ -493,14 +493,7 @@ class GenericConfigurator(Generic[TRegistry]):
             custom_globals[key] = val
         return {
             "request": request,
-            "gettext": lczr.gettext,
-            "ngettext": lczr.ngettext,
-            "dgettext": lczr.dgettext,
-            "dngettext": lczr.dngettext,
-            "pgettext": lczr.pgettext,
-            "dpgettext": lczr.dpgettext,
-            "npgettext": lczr.npgettext,
-            "dnpgettext": lczr.dnpgettext,
+            **lczr.as_dict(),
             **custom_globals,
             **request.renderer_globals,
         }

--- a/src/fastlife/service/translations.py
+++ b/src/fastlife/service/translations.py
@@ -2,7 +2,7 @@
 
 import pathlib
 from collections import defaultdict
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from gettext import GNUTranslations
 from io import BufferedReader
 from typing import Any
@@ -100,6 +100,19 @@ class Localizer:
         trans = GNUTranslations(file)
         self.translations[domain].merge(trans)
         self.global_translations.merge(trans)
+
+    def as_dict(self) -> Mapping[str, Callable[..., str]]:
+        return {
+            "_": self.gettext,
+            "gettext": self.gettext,
+            "ngettext": self.ngettext,
+            "dgettext": self.dgettext,
+            "dngettext": self.dngettext,
+            "pgettext": self.pgettext,
+            "dpgettext": self.dpgettext,
+            "npgettext": self.npgettext,
+            "dnpgettext": self.dnpgettext,
+        }
 
     def __call__(self, message: str, /, **mapping: Any) -> str:
         return self.gettext(message, **mapping)

--- a/src/fastlife/views/pydantic_form.py
+++ b/src/fastlife/views/pydantic_form.py
@@ -31,6 +31,11 @@ async def show_widget(
         field = FieldInfo(title=title)
     # FIXME: .jinja should not be hardcoded
     renderer = cast(JinjaxRenderer, request.registry.get_renderer(".jinja")(request))
+    lczr = request.registry.localizer(request.locale_name)
+    renderer.globals = {
+        "request": request,
+        **lczr.as_dict(),
+    }
     data = renderer.pydantic_form_field(
         model=model_cls,  # type: ignore
         name=name,

--- a/tests/unittests/config/test_configurator.py
+++ b/tests/unittests/config/test_configurator.py
@@ -141,6 +141,7 @@ async def test_global_vars(conf: Configurator, dummy_request_param: Any):
         "dngettext": lczr.dngettext,
         "dnpgettext": lczr.dnpgettext,
         "dpgettext": lczr.dpgettext,
+        "_": lczr.gettext,
         "gettext": lczr.gettext,
         "ngettext": lczr.ngettext,
         "npgettext": lczr.npgettext,


### PR DESCRIPTION
Combining the TranslatableStringFactory to translate title, placeholder on pydantic form fields, now they are translated while rendering template using the installed localizer.
The null localizer is installed by default.