### PR TITLE
Make template engine optionals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,14 +18,12 @@ requires-python = ">=3.11"
 dependencies = [
   "fastapi[standard] >=0.115.4,<0.116.0",
   "itsdangerous >=2.1.2,<3",
-  "jinjax >=0.48,<0.49",
   "markupsafe >=2.1.3,<3",
   "multidict >=6.0.5,<7",
   "pydantic >=2.5.3,<3",
   "pydantic-settings >=2.0.3,<3",
   "python-multipart >=0.0.13,<1",
   "venusian >=3.0.0,<4",
-  "xcomponent>=0.6.6",
 ]
 
 [project.urls]
@@ -36,6 +34,8 @@ Issues = "https://github.com/mardiros/fastlife/issues"
 Changelog = "https://mardiros.github.io/fastlife/user/changelog.html"
 
 [project.optional-dependencies]
+jinjax = ["jinjax >=0.48,<0.49"]
+xcomponent = ["xcomponent >=0.6.6,<0.7"]
 testing = ["beautifulsoup4"]
 docs = [
   "furo >=2024.5.6",
@@ -53,6 +53,7 @@ dev = [
   "heroicons >= 2.7.0,<3",
   "httpx >= 0.28.1,<0.29",
   "hypercorn >= 0.14.4,<0.15",
+  "jinjax >=0.48,<0.49",
   "mypy >= 1.4.0,<2",
   "pytailwindcss >= 0.2.0,<0.3",
   "pytest >= 8.2.0,<9",
@@ -63,6 +64,7 @@ dev = [
   "tursu >=0.16.0,<1",
   "types-beautifulsoup4 >=4.12.0.6,<5",
   "uvicorn >=0.34.0,<1.0",
+  "xcomponent >=0.6.6,<0.7",
 ]
 doc = [
   "furo >=2024.5.6",

--- a/src/fastlife/adapters/jinjax/renderer.py
+++ b/src/fastlife/adapters/jinjax/renderer.py
@@ -167,4 +167,6 @@ class JinjaxEngine(AbstractTemplateRendererFactory):
 
 @configure
 def includeme(conf: Configurator) -> None:
-    conf.add_renderer("jinjax", JinjaxEngine(conf.registry.settings))
+    conf.add_renderer(
+        conf.registry.settings.jinjax_file_ext, JinjaxEngine(conf.registry.settings)
+    )

--- a/src/fastlife/config/configurator.py
+++ b/src/fastlife/config/configurator.py
@@ -178,15 +178,11 @@ class GenericConfigurator(Generic[TRegistry]):
 
         # register our main template renderer at then end, to ensure that
         # if settings have been manipulated, everything is taken into account.
-        self.add_renderer(
-            self.registry.settings.jinjax_file_ext,
-            resolve("fastlife.adapters.jinjax.renderer:JinjaxEngine")(
-                self.registry.settings
-            ),
-        )
-
-        self.include("fastlife.adapters.jinjax")
-        self.include("fastlife.adapters.xcomponent")
+        for optional_adapter in ("jinjax", "xcomponent"):
+            try:
+                self.include(f"fastlife.adapters.{optional_adapter}")
+            except ImportError:
+                pass
 
         app = FastAPI(
             title=self.api_title,

--- a/src/fastlife/service/csrf.py
+++ b/src/fastlife/service/csrf.py
@@ -11,7 +11,7 @@ to process the request, otherwise an exception
 The cookie named is configurabllefia the settings
 :attr:`fastlife.config.settings.Settings.csrf_token_name`
 
-While using the `<Form/>` JinjaX tag, the csrf token is always sent.
+While using the `<Form/>` from XComponent or JinjaX, the csrf token is always sent.
 
 The cookie is always set when you render any template. At the moment, there is
 no way to prevent to set the cookie in the request.

--- a/src/fastlife/service/templates.py
+++ b/src/fastlife/service/templates.py
@@ -1,8 +1,12 @@
 """
 Base class to of the template renderer.
 
-Fastlife comes with {class}`fastlife.adapters.jinjax.renderer.JinjaxEngine`,
-the rendering engine.
+Fastlife comes with two rendering engines:
+{class}`fastlife.adapters.jinjax.renderer.JinjaxEngine`,
+and {class}`fastlife.adapters.xcomponent.renderer.XRendererFactory`,
+they have to be installed using python packaging extra syntax for your tool,
+fastlifeweb[jinjax] or fastlifeweb[xcomponent] since those engine are not
+installed by default.
 
 More template engine can be registered using the configurator method
 {meth}`add_renderer <fastlife.config.configurator.GenericConfigurator.add_renderer>`

--- a/src/fastlife/views/pydantic_form.py
+++ b/src/fastlife/views/pydantic_form.py
@@ -19,7 +19,7 @@ async def show_widget(
     title: str | None = Query(None),
     name: str | None = Query(None),
     token: str | None = Query(None),
-    format: Literal["jinjax", "xcomponent"] = Query("jinjax"),
+    format: Literal["jinjax", "xcomponent"] | str = Query("jinjax"),
     removable: bool = Query(False),
 ) -> Response:
     """
@@ -30,6 +30,9 @@ async def show_widget(
     if title:
         field = FieldInfo(title=title)
 
+    if format == "jinjax":
+        # XXX
+        format = request.registry.settings.jinjax_file_ext
     rndr = request.registry.get_renderer(f".{format}")(request)
     lczr = request.registry.localizer(request.locale_name)
     rndr.globals.update({"request": request, **lczr.as_dict()})

--- a/uv.lock
+++ b/uv.lock
@@ -340,14 +340,12 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "itsdangerous" },
-    { name = "jinjax" },
     { name = "markupsafe" },
     { name = "multidict" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "venusian" },
-    { name = "xcomponent" },
 ]
 
 [package.optional-dependencies]
@@ -358,8 +356,14 @@ docs = [
     { name = "sphinx" },
     { name = "sphinx-autodoc2" },
 ]
+jinjax = [
+    { name = "jinjax" },
+]
 testing = [
     { name = "beautifulsoup4" },
+]
+xcomponent = [
+    { name = "xcomponent" },
 ]
 
 [package.dev-dependencies]
@@ -370,6 +374,7 @@ dev = [
     { name = "heroicons" },
     { name = "httpx" },
     { name = "hypercorn" },
+    { name = "jinjax" },
     { name = "mypy" },
     { name = "pytailwindcss" },
     { name = "pytest" },
@@ -380,6 +385,7 @@ dev = [
     { name = "tursu" },
     { name = "types-beautifulsoup4" },
     { name = "uvicorn" },
+    { name = "xcomponent" },
 ]
 doc = [
     { name = "furo" },
@@ -395,7 +401,7 @@ requires-dist = [
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.4,<0.116.0" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2024.5.6" },
     { name = "itsdangerous", specifier = ">=2.1.2,<3" },
-    { name = "jinjax", specifier = ">=0.48,<0.49" },
+    { name = "jinjax", marker = "extra == 'jinjax'", specifier = ">=0.48,<0.49" },
     { name = "linkify-it-py", marker = "extra == 'docs'", specifier = ">=2.0.3,<3" },
     { name = "markupsafe", specifier = ">=2.1.3,<3" },
     { name = "multidict", specifier = ">=6.0.5,<7" },
@@ -406,9 +412,9 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.0.1,<8" },
     { name = "sphinx-autodoc2", marker = "extra == 'docs'", specifier = ">=0.5.0,<1" },
     { name = "venusian", specifier = ">=3.0.0,<4" },
-    { name = "xcomponent", specifier = ">=0.6.6" },
+    { name = "xcomponent", marker = "extra == 'xcomponent'", specifier = ">=0.6.6,<0.7" },
 ]
-provides-extras = ["testing", "docs"]
+provides-extras = ["jinjax", "xcomponent", "testing", "docs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -418,6 +424,7 @@ dev = [
     { name = "heroicons", specifier = ">=2.7.0,<3" },
     { name = "httpx", specifier = ">=0.28.1,<0.29" },
     { name = "hypercorn", specifier = ">=0.14.4,<0.15" },
+    { name = "jinjax", specifier = ">=0.48,<0.49" },
     { name = "mypy", specifier = ">=1.4.0,<2" },
     { name = "pytailwindcss", specifier = ">=0.2.0,<0.3" },
     { name = "pytest", specifier = ">=8.2.0,<9" },
@@ -428,6 +435,7 @@ dev = [
     { name = "tursu", specifier = ">=0.16.0,<1" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0.6,<5" },
     { name = "uvicorn", specifier = ">=0.34.0,<1.0" },
+    { name = "xcomponent", specifier = ">=0.6.6,<0.7" },
 ]
 doc = [
     { name = "furo", specifier = ">=2024.5.6" },


### PR DESCRIPTION
Now that the migration from jinjax to xcomponent has been started,

no template engine is installed by default.